### PR TITLE
Add CMake finder for native module

### DIFF
--- a/cli/commands/_build.js
+++ b/cli/commands/_build.js
@@ -1528,7 +1528,7 @@ WindowsBuilder.prototype.generateNativeWrappers = function generateNativeWrapper
 	];
 	this.logger.info(__('Generating Native Type Wrappers'));
 
-	nativeTypeGenerator.generate(path.join(this.buildDir, 'Native'), seeds, next);
+	nativeTypeGenerator.generate(path.join(this.buildDir, 'Native'), seeds, this.modules, next);
 };
 
 /**
@@ -1610,7 +1610,10 @@ WindowsBuilder.prototype.generateCmakeList = function generateCmakeList(next) {
 	for (var i = 0; i < this.modules.length; i++) {
 		var module = this.modules[i];
 		if (module.manifest.platform == 'windows') {
-			native_modules.push({projectName: module.manifest.name});		
+			native_modules.push({
+				name: module.manifest.name,
+				path:module.modulePath.replace(/\\/g, '/')
+			});
 		}
 	}
 

--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -50,7 +50,7 @@ find_package(TitaniumWindows_UI REQUIRED)
 find_package(TitaniumWindows_Utility REQUIRED)
 
 <% for(var i = 0; i < native_modules.length; i++) { -%>
-find_package(<%= native_modules[i].projectName %> REQUIRED)
+find_package(<%= native_modules[i].name %> REQUIRED)
 <% } -%>
 
 # No user-servicable parts below this line.
@@ -132,7 +132,7 @@ target_link_libraries(${EXE_NAME} ${TitaniumWindows_Utility_LIBRARIES})
 target_link_libraries(${EXE_NAME} TitaniumWindows_Native)
 
 <% for(var i = 0; i < native_modules.length; i++) { -%>
-target_link_libraries(${EXE_NAME} <%= native_modules[i].projectName %>)
+target_link_libraries(${EXE_NAME} <%= native_modules[i].name %>)
 <% } -%>
 
 target_include_directories(${EXE_NAME} PUBLIC
@@ -152,7 +152,7 @@ target_include_directories(${EXE_NAME} PUBLIC
   ${TitaniumWindows_UI_INCLUDE_DIRS}
   ${TitaniumWindows_Utility_INCLUDE_DIRS}
 <% for(var i = 0; i < native_modules.length; i++) { -%>
-  ${<%= native_modules[i].projectName %>_INCLUDE_DIRS}
+  ${<%= native_modules[i].name %>_INCLUDE_DIRS}
 <% } -%>
 )
 
@@ -169,9 +169,6 @@ set_property(TARGET ${EXE_NAME}
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_UI/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_UI.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_Utility/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_Utility.winmd"
 <% for(var i = 0; i < native_modules.length; i++) { -%>
-<% if (native_modules[i].global) { -%>
-  "${WINDOWS_SOURCE_DIR}/lib/<%= native_modules[i].projectName %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].projectName %>.winmd"
-<% } else { -%>
-  "lib/<%= native_modules[i].projectName %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].projectName %>.winmd"
-<% }} -%>
+  "<%= native_modules[i].path %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].name %>.winmd"
+<% } -%>
 )

--- a/templates/build/CMakeLists.txt.ejs
+++ b/templates/build/CMakeLists.txt.ejs
@@ -49,6 +49,10 @@ find_package(TitaniumKit REQUIRED)
 find_package(TitaniumWindows_UI REQUIRED)
 find_package(TitaniumWindows_Utility REQUIRED)
 
+<% for(var i = 0; i < native_modules.length; i++) { -%>
+find_package(<%= native_modules[i].projectName %> REQUIRED)
+<% } -%>
+
 # No user-servicable parts below this line.
 
 if(NOT TARGET TitaniumWindows_Native)
@@ -127,6 +131,10 @@ target_link_libraries(${EXE_NAME} ${TitaniumWindows_UI_LIBRARIES})
 target_link_libraries(${EXE_NAME} ${TitaniumWindows_Utility_LIBRARIES})
 target_link_libraries(${EXE_NAME} TitaniumWindows_Native)
 
+<% for(var i = 0; i < native_modules.length; i++) { -%>
+target_link_libraries(${EXE_NAME} <%= native_modules[i].projectName %>)
+<% } -%>
+
 target_include_directories(${EXE_NAME} PUBLIC
   ${PROJECT_SOURCE_DIR}/include
   $<TARGET_PROPERTY:TitaniumWindows_Native,INTERFACE_INCLUDE_DIRECTORIES>
@@ -143,6 +151,9 @@ target_include_directories(${EXE_NAME} PUBLIC
   $<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>
   ${TitaniumWindows_UI_INCLUDE_DIRS}
   ${TitaniumWindows_Utility_INCLUDE_DIRS}
+<% for(var i = 0; i < native_modules.length; i++) { -%>
+  ${<%= native_modules[i].projectName %>_INCLUDE_DIRS}
+<% } -%>
 )
 
 set_property(TARGET ${EXE_NAME}
@@ -157,4 +168,10 @@ set_property(TARGET ${EXE_NAME}
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows/${PLATFORM}/${Ti_ARCH}/TitaniumWindows.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_UI/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_UI.winmd"
   "${WINDOWS_SOURCE_DIR}/lib/TitaniumWindows_Utility/${PLATFORM}/${Ti_ARCH}/TitaniumWindows_Utility.winmd"
+<% for(var i = 0; i < native_modules.length; i++) { -%>
+<% if (native_modules[i].global) { -%>
+  "${WINDOWS_SOURCE_DIR}/lib/<%= native_modules[i].projectName %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].projectName %>.winmd"
+<% } else { -%>
+  "lib/<%= native_modules[i].projectName %>/${PLATFORM}/${Ti_ARCH}/<%= native_modules[i].projectName %>.winmd"
+<% }} -%>
 )

--- a/templates/build/cmake/FindNativeModule.cmake.ejs
+++ b/templates/build/cmake/FindNativeModule.cmake.ejs
@@ -1,0 +1,37 @@
+# Find<%= module.manifest.name %>
+# Author: <%= module.manifest.author %>
+#
+# Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+# Author: <%= module.manifest.author %>
+# Created: <%= new Date().toDateString() %>
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+  set(PLATFORM phone)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
+  set(PLATFORM store)
+else()
+  message(FATAL_ERROR "This app supports Store / Phone only.")
+endif()
+
+set(<%= module.manifest.name %>_ARCH "x86")
+if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
+  set(<%= module.manifest.name %>_ARCH "arm")
+endif()
+
+# Create imported target <%= module.manifest.name %>
+add_library(<%= module.manifest.name %> SHARED IMPORTED)
+
+set_target_properties(<%= module.manifest.name %> PROPERTIES
+  COMPATIBLE_INTERFACE_STRING "<%= module.manifest.name %>_MAJOR_VERSION"
+  INTERFACE_INCLUDE_DIRECTORIES "<%= module.path %>/include;$<TARGET_PROPERTY:TitaniumKit,INTERFACE_INCLUDE_DIRECTORIES>"
+  INTERFACE_LINK_LIBRARIES "TitaniumKit"
+  INTERFACE_<%= module.manifest.name %>_MAJOR_VERSION "0"
+)
+
+set_target_properties(<%= module.manifest.name %> PROPERTIES
+  IMPORTED_IMPLIB "<%= module.path %>/${PLATFORM}/${<%= module.manifest.name %>_ARCH}/<%= module.manifest.name %>.lib"
+  IMPORTED_LOCATION "<%= module.path %>/${PLATFORM}/${<%= module.manifest.name %>_ARCH}/<%= module.manifest.name %>.dll"
+  )


### PR DESCRIPTION
Add native module DLL/winmd finder for CMake based on `tiapp.xml`.

Native module manifest should look like below. module's `name` will be used for generating cmake module project name. `classname` entry should be module's C++ class name. In this case module directory should have `ComExampleTest2.DLL` and `ComExampleTest2.winmd` under modulePath + `${PLATFORM}/${Ti_ARCH}` directory.

```
#
# this is your module manifest and used by Titanium
# during compilation, packaging, distribution, etc.
#
version: 0.1
apiversion: 2
description: Example module 2
author: Ping Wang
license: Apache Public License v2
copyright: Copyright (c) 2009-2015 by Appcelerator, Inc.

# these should not be edited
name: ComExampleTest2
moduleid: com.example.test2
guid: e4f7ac61-1ee7-44c5-bc27-fa6876e2dce8
platform: windows
classname: Com::Example::Test2
```
